### PR TITLE
fixing string element attributes in component.js

### DIFF
--- a/component.js
+++ b/component.js
@@ -1,13 +1,17 @@
-function Component(name, parent, _proto, extend) {
+function Component(name, _proto, parent, extend) {
+  parent = parent || HTMLElement;
+
   var proto = {};
   var protoKeys = Object.keys(_proto || {});
 
   protoKeys.forEach(function (key) {
     var attr = _proto[key];
-    if (typeof attr === 'string') {
-      attr = createElementAttribute(attr);
-    } else if (typeof attr === 'function') {
+    if (typeof attr === 'function') {
       attr = createFunctionAttribute(attr);
+    } else if (typeof attr === 'string') {
+      attr = createStringElementAttribute(attr);
+    } else if (!isDefinedProperty(attr)) {
+      attr = createElementAttribute(attr);
     }
 
     proto[key] = attr;
@@ -19,10 +23,23 @@ function Component(name, parent, _proto, extend) {
 
 module.exports = Component;
 
+function isDefinedProperty(prop) {
+  var isDataProp = 'value' in prop || 'writable' in prop;
+  var isAccessProp = 'get' in prop || 'set' in prop;
+  return isDataProp || isAccessProp;
+}
+
 function createElementAttribute(name) {
   return {
     get: function() { return JSON.parse(this.getAttribute(name)); },
     set: function(val) { return this.setAttribute(name, JSON.stringify(val)); }
+  };
+}
+
+function createStringElementAttribute(name) {
+  return {
+    get: function() { return this.getAttribute(name); },
+    set: function(val) { return this.setAttribute(name, val); }
   };
 }
 

--- a/viewer.js
+++ b/viewer.js
@@ -3,7 +3,7 @@ var Renderer = require('./renderer.js');
 
 var viewerHtml = require('./viewer.html');
 
-var Viewer = Component('kokorigami-viewer', HTMLElement, {
+var Viewer = Component('kokorigami-viewer', {
   _: {
     writable: false,
     enumerable: false,


### PR DESCRIPTION
The defaults aren't exactly there, but it should properly (not) parse string attributes.
