### PR TITLE
Emitter - Limiting exposed methods

### DIFF
--- a/example/example.js
+++ b/example/example.js
@@ -13,7 +13,7 @@ prev.addEventListener('click', function () { viewer.prev(); });
 next.addEventListener('click', function () { viewer.next(); });
 reset.addEventListener('click', function () { viewer.frame = 0; });
 
-viewer.emitter.on('update', function (newFrame) {
+viewer.on('update', function (newFrame) {
   frame.value = newFrame;
 });
 

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -6,11 +6,11 @@ var EventEmitter = require('events');
 var Viewer = function (el) {
   this.el = el || document.createElement('canvas');
   this.renderer = new Renderer(this.el);
+  this._emitter = new EventEmitter();
   this._model = new Model();
   this._frame = 0;
   this.raf = null;
   this.controls = null;
-  this.emitter = new EventEmitter();
 
   this.el.classList.add('kokorigami-viewer');
   return this;
@@ -70,7 +70,20 @@ Viewer.prototype.prev = function () {
 Viewer.prototype.destroy = function () {
   this.stop();
   this.renderer.stop();
+  this._emitter.removeAllListeners();
   controls.remove(this.el, this.controls);
+};
+
+Viewer.prototype.on = function (event, callback) {
+  this._emitter.on(event, callback);
+};
+
+Viewer.prototype.once = function (event, callback) {
+  this._emitter.once(event, callback);
+};
+
+Viewer.prototype.off = function (event, callback) {
+  this._emitter.removeListener(event, callback);
 };
 
 Object.defineProperty(Viewer.prototype, 'model', {
@@ -95,7 +108,7 @@ Object.defineProperty(Viewer.prototype, 'frame', {
     this._frame = frame;
     this.renderer.data(this.model.frameGeometry(frame));
 
-    this.emitter.emit('update', frame);
+    this._emitter.emit('update', frame);
     return frame;
   },
 

--- a/test/viewer.js
+++ b/test/viewer.js
@@ -15,7 +15,7 @@ describe('viewer', function () {
     var viewer = new Viewer();
     var callback = chai.spy();
 
-    viewer.emitter.on('update', callback);
+    viewer.on('update', callback);
     viewer.frame = 1;
     expect(callback).to.have.been.called();
   });

--- a/test/viewer.js
+++ b/test/viewer.js
@@ -1,9 +1,22 @@
-var expect = require('chai').expect;
+
+var chai = require('chai');
+var spies = require('chai-spies');
+var expect = chai.expect;
+chai.use(spies);
 var Viewer = require('../src/viewer.js');
 
 describe('viewer', function () {
   it('can be created', function () {
     var viewer = new Viewer();
     expect(viewer).to.exist;
+  });
+
+  it('emits update when the frame is updated', function () {
+    var viewer = new Viewer();
+    var callback = chai.spy();
+
+    viewer.emitter.on('update', callback);
+    viewer.frame = 1;
+    expect(callback).to.have.been.called();
   });
 });


### PR DESCRIPTION
I decided that I didn't like having people directly interact with the viewer's emitter, so I exposed the following functions:
- on
- once
- off (removeListener)

Also added a test and listeners are removed on destroy.
