### PR TITLE
adding playStep, adjustable fps, play and stop events

### DIFF
--- a/src/actionbar.js
+++ b/src/actionbar.js
@@ -22,8 +22,8 @@ function ActionBar(viewer, el) {
   this.frame = this.el.querySelector('.frame');
   this.bar = this.el.querySelector('.progress');
 
-  this._onClickPrev = function () { viewer.prev(); };
-  this._onClickNext = function () { viewer.next(); };
+  this._onClickPrev = function () { viewer.playStep(viewer.step - 1); };
+  this._onClickNext = function () { viewer.playStep(viewer.step); };
   this._onClickReset = function () { viewer.frame = 0; };
   this.update = this.update.bind(this);
 

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -39,7 +39,7 @@ Viewer.prototype.play = function (frame, fps) {
   var start;
 
   var render = function (timestamp) {
-    if (!start) start = timestamp;
+    start = start || timestamp;
 
     var delta = (timestamp - start) / animationTime;
     delta = Math.min(delta, 1);
@@ -48,9 +48,12 @@ Viewer.prototype.play = function (frame, fps) {
 
     if (this.frame !== frame) {
       this.raf = requestAnimationFrame(render);
+    } else {
+      this._emitter.emit('stop');
     }
   }.bind(this);
   this.raf = requestAnimationFrame(render);
+  this._emitter.emit('play');
 };
 
 Viewer.prototype.playStep = function (step, fps) {
@@ -64,7 +67,10 @@ Viewer.prototype.playStep = function (step, fps) {
 };
 
 Viewer.prototype.stop = function () {
+  if (!this.raf) return;
   cancelAnimationFrame(this.raf);
+  this.raf = null;
+  this._emitter.emit('stop');
 };
 
 Viewer.prototype.destroy = function () {

--- a/test/viewer.js
+++ b/test/viewer.js
@@ -46,13 +46,16 @@ describe('viewer', function () {
 
   it('can play to a specific frame', function (done) {
     var viewer = new Viewer();
-    viewer.model = model;
-    viewer.play(2, 100);
-    expect(viewer.frame).to.equal(0);
-    setTimeout(function () {
+    var check = function () {
       expect(viewer.frame).to.equal(2);
       done();
-    }, 40);
+    };
+    viewer.model = model;
+    viewer.play(2, 1000);
+    expect(viewer.frame).to.equal(0);
+    setTimeout(function () {
+      requestAnimationFrame(check);
+    }, 10);
   });
 
   it('can play a specific step', function () {

--- a/test/viewer.js
+++ b/test/viewer.js
@@ -51,11 +51,9 @@ describe('viewer', function () {
       done();
     };
     viewer.model = model;
+    viewer.on('stop', check);
     viewer.play(2, 1000);
     expect(viewer.frame).to.equal(0);
-    setTimeout(function () {
-      requestAnimationFrame(check);
-    }, 10);
   });
 
   it('can play a specific step', function () {

--- a/test/viewer.js
+++ b/test/viewer.js
@@ -4,25 +4,65 @@ var spies = require('chai-spies');
 var expect = chai.expect;
 chai.use(spies);
 var Viewer = require('../src/viewer.js');
+var Model = require('../src/model.js');
+var data = require('./data.json');
 
 describe('viewer', function () {
+  var model = new Model(data);
+
   it('can be created', function () {
     var viewer = new Viewer();
     expect(viewer).to.exist;
-  });
-
-  it('emits update when the frame is updated', function () {
-    var viewer = new Viewer();
-    var callback = chai.spy();
-
-    viewer.on('update', callback);
-    viewer.frame = 1;
-    expect(callback).to.have.been.called();
   });
 
   it('can set the background color', function () {
     var viewer = new Viewer();
     viewer.background = [0, 255, 255, 102];
     expect(viewer.el.style.backgroundColor).to.equal('rgba(0, 255, 255, 0.4)');
+  });
+
+  it('can update frames', function () {
+    var viewer = new Viewer();
+    viewer.model = model;
+    viewer.frame = 1;
+    expect(viewer.frame).to.equal(1);
+  });
+
+  it('emits update when the frame is updated', function () {
+    var callback = chai.spy();
+    var viewer = new Viewer();
+    viewer.model = model;
+    viewer.on('update', callback);
+    viewer.frame = 1;
+    expect(callback).to.have.been.called();
+  });
+
+  it('can determine the current step', function () {
+    var viewer = new Viewer();
+    viewer.model = model;
+    viewer.frame = data.fps + 1;
+    expect(viewer.step).to.equal(1);
+  });
+
+  it('can play to a specific frame', function (done) {
+    var viewer = new Viewer();
+    viewer.model = model;
+    viewer.play(2, 100);
+    expect(viewer.frame).to.equal(0);
+    setTimeout(function () {
+      expect(viewer.frame).to.equal(2);
+      done();
+    }, 40);
+  });
+
+  it('can play a specific step', function () {
+    var viewer = new Viewer();
+    viewer.model = model;
+    chai.spy.on(viewer, 'play');
+
+    viewer.playStep(1);
+    expect(viewer.step).to.equal(1);
+    expect(viewer.frame).to.equal(data.fps);
+    expect(viewer.play).to.have.been.called.with(data.fps * 2);
   });
 });


### PR DESCRIPTION
I'm still thinking about the actionBar interface and this is a sort of prerequisite.

Thoughts on the action bar (for future PR):
- Progress bar: Display current model progress. Allow users to "scrub" for a specific frame as well as show step boundaries and allow users to select a step.
- Play button: Plays the current step or the next step. Hidden while in progress.
- Pause button: Shown when the play is in progress. Pauses on a specific frame.
- Replay button: I'm not sure about this one. The functionality is made available through the progress bar, but if this is a common enough behavior we should have the button.
