### PR TITLE
moving browserify dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
   "author": "",
   "dependencies": {
     "3d-view": "^2.0.0",
+    "browserify": "^12.0.2",
+    "browserify-css": "^0.9.1",
     "get-pixels": "^3.3.0",
     "get-plane-normal": "^1.0.0",
     "gl-big-quad": "^1.0.0",
@@ -18,14 +20,12 @@
     "gl-mat4": "^1.1.4",
     "gl-shader": "^4.2.0",
     "gl-texture2d": "^2.0.10",
-    "gl-vec3": "^1.0.3"
+    "gl-vec3": "^1.0.3",
+    "glslify": "^4.0.0"
   },
   "devDependencies": {
-    "browserify": "^12.0.2",
-    "browserify-css": "^0.9.1",
     "chai": "^3.4.1",
     "chai-spies": "^0.7.1",
-    "glslify": "^4.0.0",
     "karma": "^0.13.22",
     "karma-browserify": "^5.0.5",
     "karma-firefox-launcher": "^1.0.0",


### PR DESCRIPTION
Moved browserify related dependencies from devDependencies to dependencies. This is because when the app requires the kokorigami-viewer module and we try to build the app with browserify, it will throw an error saying that the browserify plugins don't exist.

There are some alternative solutions:
- put browserify-css and glslify in peerDependencies and add them to app dependencies
- build the viewer and use the built file as the main
